### PR TITLE
Add option to skip files and directories located in other filesystems

### DIFF
--- a/compsize.8
+++ b/compsize.8
@@ -77,6 +77,9 @@ In this case, we have: \fBDisk Usage\fR: 8KB, \fBUncompressed\fR: 160K,
 .TP
 .BR -b / --bytes
 Show raw byte counts rather than human-friendly sizes.
+.TP
+.BR -x / --one-file-system
+Skip files and directories on different file systems.
 .SH CAVEATS
 Recently written files may show as not taking any space until they're
 actually allocated and compressed; this happens once they're synced or


### PR DESCRIPTION
So that we can do something like:
`# compsize -x /`

Without this, the command may hit something like:
`SEARCH_V2: Inappropriate ioctl for device`

