### PR TITLE
Use secure URI in Homepage field.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+btrfs-compsize (1.2-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Thu, 13 Sep 2018 13:58:35 +0100
+
 btrfs-compsize (1.2-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper (>> 11~), libbtrfs-dev | btrfs-progs (<< 4.16.1~)
 Standards-Version: 4.1.4
 Rules-Requires-Root: no
-Homepage: http://github.com/kilobyte/compsize
+Homepage: https://github.com/kilobyte/compsize
 Vcs-Git: https://github.com/kilobyte/compsize.git -b debian
 Vcs-Browser: https://github.com/kilobyte/compsize/tree/debian
 


### PR DESCRIPTION
Use secure URI in Homepage field.

Fixes lintian: homepage-field-uses-insecure-uri
See https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html for more details.
