### PR TITLE
Musl libc fixes

### DIFF
--- a/compsize.c
+++ b/compsize.c
@@ -13,6 +13,7 @@
 #include <inttypes.h>
 #include <linux/limits.h>
 #include <getopt.h>
+#include <signal.h>
 #include "radix-tree.h"
 #include "endianness.h"
 

--- a/compsize.c
+++ b/compsize.c
@@ -241,7 +241,7 @@ static void do_recursive_search(const char *path, struct workspace *ws, const de
             print_stats(ws);
         }
 
-        fd = open(path, O_RDONLY|O_NOFOLLOW|O_NOCTTY|O_NONBLOCK|__O_LARGEFILE);
+        fd = open(path, O_RDONLY|O_NOFOLLOW|O_NOCTTY|O_NONBLOCK);
         if (fd == -1)
         {
             if (errno == ELOOP    // symlink


### PR DESCRIPTION
I was just packaging compsize and found [it won't build for musl](https://travis-ci.org/void-linux/void-packages/jobs/497689395).

Musl is a little more picky about what includes you need, so I added the missing `signal.h`. Other than that I *think* the use of `__O_LARGEFILE` is unnecessary and discuraged and using `#define _FILE_OFFSET_BITS 64` ist the prefered way to do things, even on glibc (see man 2 open).

I confirmed these changes to work with `x86_64-musl`. 