### PR TITLE
fix build with btrfs-progs >= 6.10.1

### DIFF
--- a/compsize.c
+++ b/compsize.c
@@ -5,12 +5,14 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <dirent.h>
+#include "kerncompat.h"
 #include <btrfs/ioctl.h>
 #include <btrfs/ctree.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <inttypes.h>
+#include <errno.h>
 #include <linux/limits.h>
 #include <getopt.h>
 #include <signal.h>

--- a/radix-tree.h
+++ b/radix-tree.h
@@ -37,11 +37,7 @@
 #ifndef _LINUX_RADIX_TREE_H
 #define _LINUX_RADIX_TREE_H
 
-#if BTRFS_FLAT_INCLUDES
 #include "kerncompat.h"
-#else
-#include <btrfs/kerncompat.h>
-#endif /* BTRFS_FLAT_INCLUDES */
 
 #define RADIX_TREE_MAX_TAGS 2
 


### PR DESCRIPTION
This patch force using the included kerncompat.h header file. Because btrfs-progs removed a bunch of declarations from the header files it fails to compile if kerncompat.h from btrfs-progs is used.  See next error log.

```
In file included from compsize.c:17:
radix-tree.h:51:9: error: unknown type name ‘gfp_t’
   51 |         gfp_t                   gfp_mask;
      |         ^~~~~
radix-tree.h:78:24: error: unknown type name ‘gfp_t’
   78 | int radix_tree_preload(gfp_t gfp_mask);
      |                        ^~~~~
radix-tree.h: In function ‘radix_tree_preload_end’:
radix-tree.h:94:9: error: implicit declaration of function ‘preempt_enable’ [-Wimplicit-function-declaration]
   94 |         preempt_enable();
      |         ^~~~~~~~~~~~~~
compsize.c: In function ‘parse_file_extent_item’:
compsize.c:163:10: error: implicit declaration of function ‘IS_ALIGNED’ [-Wimplicit-function-declaration]
  163 |     if (!IS_ALIGNED(disk_bytenr, 1 << 12))
      |          ^~~~~~~~~~
compsize.c:167:5: error: implicit declaration of function ‘radix_tree_preload’; did you mean ‘radix_tree_preload_end’? [-Wimplicit-function-declaration]
  167 |     radix_tree_preload(GFP_KERNEL);
      |     ^~~~~~~~~~~~~~~~~~
      |     radix_tree_preload_end
compsize.c:167:24: error: ‘GFP_KERNEL’ undeclared (first use in this function); did you mean ‘SI_KERNEL’?
  167 |     radix_tree_preload(GFP_KERNEL);
      |                        ^~~~~~~~~~
      |                        SI_KERNEL
compsize.c:167:24: note: each undeclared identifier is reported only once for each function it appears in
compsize.c: In function ‘do_file’:
compsize.c:194:13: error: ‘errno’ undeclared (first use in this function)
  194 |         if (errno == ENOTTY)
      |             ^~~~~
compsize.c:19:1: note: ‘errno’ is defined in header ‘<errno.h>’; this is probably fixable by adding ‘#include <errno.h>’
   18 | #include "endianness.h"
  +++ |+#include <errno.h>
   19 | 
compsize.c:194:22: error: ‘ENOTTY’ undeclared (first use in this function); did you mean ‘N_TTY’?
  194 |         if (errno == ENOTTY)
      |                      ^~~~~~
      |                      N_TTY
compsize.c: In function ‘do_recursive_search’:
compsize.c:246:17: error: ‘errno’ undeclared (first use in this function)
  246 |             if (errno == ELOOP    // symlink
      |                 ^~~~~
compsize.c:246:17: note: ‘errno’ is defined in header ‘<errno.h>’; this is probably fixable by adding ‘#include <errno.h>’
compsize.c:246:26: error: ‘ELOOP’ undeclared (first use in this function)
  246 |             if (errno == ELOOP    // symlink
      |                          ^~~~~
compsize.c:247:26: error: ‘ENXIO’ undeclared (first use in this function)
  247 |              || errno == ENXIO    // some device nodes
      |                          ^~~~~
compsize.c:248:26: error: ‘ENODEV’ undeclared (first use in this function); did you mean ‘NODEV’?
  248 |              || errno == ENODEV   // /dev/ptmx
      |                          ^~~~~~
      |                          NODEV
compsize.c:249:26: error: ‘ENOMEDIUM’ undeclared (first use in this function)
  249 |              || errno == ENOMEDIUM// more device nodes
      |                          ^~~~~~~~~
compsize.c:250:26: error: ‘ENOENT’ undeclared (first use in this function)
  250 |              || errno == ENOENT)  // something just deleted
      |                          ^~~~~~
compsize.c:252:31: error: ‘EACCES’ undeclared (first use in this function)
  252 |             else if (errno == EACCES)
```

This is a minimal patch which may be superseded by https://github.com/kilobyte/compsize/pull/53 